### PR TITLE
StatsPage servlet and datastore logic to provide requested data

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -19,6 +19,7 @@ package com.google.codeu.data;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;

--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -83,11 +83,11 @@ public class Datastore {
 
   /**
    * Gets total number of messages posted.
-   * @return an integer respresenting the total numner of messages posted on the webpage.
+   * 
+   * @return an integer respresenting the total number of messages posted on the webpage.
    */
   public int getTotalMessageCount() {
-    Query query = new Query("Message");
-    PreparedQuery results = datastore.prepare(query);
+    PreparedQuery results = datastore.prepare(new Query("Message"));
     return results.countEntities(FetchOptions.Builder.withLimit(1000));
   }
 }

--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -79,4 +79,14 @@ public class Datastore {
 
     return messages;
   }
+
+  /**
+   * Gets total number of messages posted.
+   * @return an integer respresenting the total numner of messages posted on the webpage.
+   */
+  public int getTotalMessageCount() {
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    return results.countEntities(FetchOptions.Builder.withLimit(1000));
+  }
 }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -10,9 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.google.codeu.data.Datastore;
 import com.google.gson.JsonObject;
 
-/**
- * Handles fetching site statistics
- */
+// Handles fetching site statistics
 @WebServlet("/stats")
 public class StatsPageServlet extends HttpServlet {
 
@@ -23,9 +21,7 @@ public class StatsPageServlet extends HttpServlet {
         datastore = new Datastore();
     }
 
-    /**
-     * Responds with site statistics in JSON
-     */
+    // Responds with site statistics in JSON
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
@@ -38,5 +34,3 @@ public class StatsPageServlet extends HttpServlet {
         response.getOutputStream().println(jsonObject.toString());
     }
 }
-
-

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -1,0 +1,22 @@
+package main.java.com.google.codeu.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * responds with hard coded message for test purposes
+ */
+@WebServlet("/stats")
+public class StatsPageServlet extends HttpServlet {
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        response.getOutputStream().println("hello world");
+    }
+}
+
+

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -1,4 +1,4 @@
-package main.java.com.google.codeu.servlets;
+package com.google.codeu.servlets;
 
 import java.io.IOException;
 
@@ -7,15 +7,35 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.codeu.data.Datastore;
+import com.google.gson.JsonObject;
+
 /**
- * responds with hard coded message for test purposes
+ * Handles fetching site statistics
  */
 @WebServlet("/stats")
 public class StatsPageServlet extends HttpServlet {
+
+    private Datastore datastore;
+
+    @Override
+    public void init() {
+        datastore = new Datastore();
+    }
+
+    /**
+     * Responds with site statistics in JSON
+     */
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
-        response.getOutputStream().println("hello world");
+        response.setContentType("application/json");
+
+        int messageCount = datastore.getTotalMessageCount();
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("messageCount", messageCount);
+        response.getOutputStream().println(jsonObject.toString());
     }
 }
 


### PR DESCRIPTION
Created StatsPageServlet, with route "/stats". Shows the messageCount.
Implemented method in Datastore to get the total message count of the site.
Fixed errors:
correct package (StatsPageServlet)
imported FetchOptions (Datastore)
